### PR TITLE
gettimeofday() 実装の追加

### DIFF
--- a/src/Saba/Base/Time.cpp
+++ b/src/Saba/Base/Time.cpp
@@ -10,7 +10,10 @@
 #if _WIN32
 #include <Windows.h>
 #else // _WIN32
-#include <time.h>
+#include <ctime>
+#if (_POSIX_TIMERS <= 0) || !defined(_POSIX_MONOTONIC_CLOCK)
+#include <sys/time.h>
+#endif
 #endif // _WIN32
 
 namespace saba
@@ -47,10 +50,17 @@ namespace saba
 
 			double GetTime() const
 			{
+# if (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
 				timespec ts;
 				clock_gettime(CLOCK_MONOTONIC, &ts);
 				uint64_t time = (uint64_t)ts.tv_sec * 1000000000 + (uint64_t)ts.tv_nsec;
 				return (double)time / 1000000000.0;
+#else
+				timeval tv;
+				gettimeofday(&tv, 0);
+				uint64_t time = (uint64_t)tv.tv_sec * 1000000 + (uint64_t)tv.tv_usec;
+				return (double)time / 1000000.0;
+#endif
 			}
 		};
 #endif // _WIN32


### PR DESCRIPTION
Mac OS X でビルドしたところ以下のようなエラーが出ました。

`Time.cpp:51:19: error: use of undeclared identifier 'CLOCK_MONOTONIC'`

そこで `clock_gettime()` のない環境や `CLOCK_MONOTONIC` の対応していない環境で、代わりに`gettimeofday` を使うように修正しました。

`clock_gettime()`のある環境で `clock_gettime()` を使ってくれるかどうかは確認していません。

参考: <https://linuxjm.osdn.jp/html/LDP_man-pages/man2/clock_gettime.2.html>