### PR TITLE
物理挙動がおかしかったのを修正

### DIFF
--- a/src/Saba/Model/MMD/MMDModel.h
+++ b/src/Saba/Model/MMD/MMDModel.h
@@ -160,6 +160,7 @@ namespace saba
 		// ノードを更新する
 		virtual void UpdateAnimation() = 0;
 		// Physicsを更新する
+		virtual void ResetPhysics() = 0;
 		virtual void UpdatePhysics(float elapsed) = 0;
 		// 頂点を更新する
 		virtual void Update() = 0;

--- a/src/Saba/Model/MMD/MMDPhysics.cpp
+++ b/src/Saba/Model/MMD/MMDPhysics.cpp
@@ -32,15 +32,28 @@ namespace saba
 		}
 	}
 
+	struct MMDFilterCallback : public btOverlapFilterCallback
+	{
+		bool needBroadphaseCollision(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) const override
+		{
+			auto findIt = std::find_if(
+				m_nonFilterProxy.begin(),
+				m_nonFilterProxy.end(),
+				[proxy0, proxy1](const auto& x) {return x == proxy0 || x == proxy1; }
+			);
+			if (findIt != m_nonFilterProxy.end())
+			{
+				return true;
+			}
+			bool collides = (proxy0->m_collisionFilterGroup & proxy1->m_collisionFilterMask) != 0;
+			collides = collides && (proxy1->m_collisionFilterGroup & proxy0->m_collisionFilterMask);
+			return collides;
+		}
+
+		std::vector<btBroadphaseProxy*> m_nonFilterProxy;
+	};
+
 	MMDPhysics::MMDPhysics()
-		: m_broadphase(nullptr)
-		, m_collisionConfig(nullptr)
-		, m_dispatcher(nullptr)
-		, m_solver(nullptr)
-		, m_world(nullptr)
-		, m_groundShape(nullptr)
-		, m_groundMS(nullptr)
-		, m_groundRB(nullptr)
 	{
 	}
 
@@ -77,6 +90,11 @@ namespace saba
 		m_groundRB = std::make_unique<btRigidBody>(groundInfo);
 
 		m_world->addRigidBody(m_groundRB.get());
+
+		auto filterCB = std::make_unique<MMDFilterCallback>();
+		filterCB->m_nonFilterProxy.push_back(m_groundRB->getBroadphaseProxy());
+		m_world->getPairCache()->setOverlapFilterCallback(filterCB.get());
+		m_filterCB = std::move(filterCB);
 
 		return true;
 	}
@@ -188,18 +206,57 @@ namespace saba
 		{
 			m_invOffset = glm::inverse(offset);
 			m_nodeGlobal = m_node->GetGlobalTransform();
+			Reset();
 		}
 
 		void getWorldTransform(btTransform& worldTransform) const override
 		{
-			glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
-			worldTransform.setFromOpenGLMatrix(&ret[0][0]);
+			//glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
+			//worldTransform.setFromOpenGLMatrix(&ret[0][0]);
+			worldTransform = m_transform;
 		}
 
 		void setWorldTransform(const btTransform& worldTransform) override
 		{
+			//glm::mat4 world;
+			//worldTransform.getOpenGLMatrix(&world[0][0]);
+			//m_nodeGlobal = InvZ(world) * m_invOffset;
+
+			//MMDNode* parent = m_node->GetParent();
+			//glm::mat4 local;
+			//if (parent != nullptr)
+			//{
+			//	local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
+			//}
+			//else
+			//{
+			//	local = m_nodeGlobal;
+			//}
+
+			//if (m_override)
+			//{
+			//	m_node->SetLocalTransform(local);
+			//	m_node->UpdateGlobalTransform();
+			//}
+			m_transform = worldTransform;
+		}
+
+		void Reset() override
+		{
+			m_nodeGlobal = m_node->GetGlobalTransform();
+
+			glm::mat4 global = InvZ(m_node->GetGlobalTransform() * m_offset);
+			m_transform.setFromOpenGLMatrix(&global[0][0]);
+		}
+
+		void BeginUpdate() override
+		{
+		}
+
+		void EndUpdate() override
+		{
 			glm::mat4 world;
-			worldTransform.getOpenGLMatrix(&world[0][0]);
+			m_transform.getOpenGLMatrix(&world[0][0]);
 			m_nodeGlobal = InvZ(world) * m_invOffset;
 
 			MMDNode* parent = m_node->GetParent();
@@ -220,24 +277,12 @@ namespace saba
 			}
 		}
 
-		void Reset() override
-		{
-			m_nodeGlobal = m_node->GetGlobalTransform();
-		}
-
-		void BeginUpdate() override
-		{
-		}
-
-		void EndUpdate() override
-		{
-		}
-
 	private:
 		MMDNode*	m_node;
 		glm::mat4	m_nodeGlobal;
 		glm::mat4	m_offset;
 		glm::mat4	m_invOffset;
+		btTransform	m_transform;
 		bool		m_override;
 	};
 
@@ -252,62 +297,90 @@ namespace saba
 			m_invOffset = glm::inverse(offset);
 			m_nodeLocal = m_node->GetLocalTransform();
 			m_nodeGlobal = m_node->GetGlobalTransform();
+			Reset();
 		}
 
 		void getWorldTransform(btTransform& worldTransform) const override
 		{
-			glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
-			worldTransform.setFromOpenGLMatrix(&ret[0][0]);
+			//glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
+			//worldTransform.setFromOpenGLMatrix(&ret[0][0]);
+			worldTransform = m_transform;
 		}
 
 		void setWorldTransform(const btTransform& worldTransform) override
 		{
-			glm::mat4 world;
-			worldTransform.getOpenGLMatrix(&world[0][0]);
-			world = InvZ(world);
-			glm::mat4 nodeOffsetGlobal = m_node->GetGlobalTransform() * m_offset;
-			world[3] = nodeOffsetGlobal[3];
-			m_nodeGlobal = world * m_invOffset;
+			//glm::mat4 world;
+			//worldTransform.getOpenGLMatrix(&world[0][0]);
+			//world = InvZ(world);
+			//glm::mat4 nodeOffsetGlobal = m_node->GetGlobalTransform() * m_offset;
+			//world[3] = nodeOffsetGlobal[3];
+			//m_nodeGlobal = world * m_invOffset;
 
-			MMDNode* parent = m_node->GetParent();
-			if (parent != nullptr)
-			{
-				glm::mat4 local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
-				m_nodeLocal = local;
-			}
-			else
-			{
-				m_nodeLocal = m_nodeGlobal;
-			}
+			//MMDNode* parent = m_node->GetParent();
+			//if (parent != nullptr)
+			//{
+			//	glm::mat4 local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
+			//	m_nodeLocal = local;
+			//}
+			//else
+			//{
+			//	m_nodeLocal = m_nodeGlobal;
+			//}
 
-			if (m_override)
-			{
-				m_node->SetLocalTransform(m_nodeLocal);
-				m_node->UpdateGlobalTransform();
-			}
+			//if (m_override)
+			//{
+			//	m_node->SetLocalTransform(m_nodeLocal);
+			//	m_node->UpdateGlobalTransform();
+			//}
+			m_transform = worldTransform;
 		}
 
 		void Reset() override
 		{
 			m_nodeLocal = m_node->GetLocalTransform();
 			m_nodeGlobal = m_node->GetGlobalTransform();
+
+			glm::mat4 global = InvZ(m_node->GetGlobalTransform() * m_offset);
+			m_transform.setFromOpenGLMatrix(&global[0][0]);
 		}
 
 		void BeginUpdate() override
 		{
-			MMDNode* parent = m_node->GetParent();
-			if (parent != nullptr)
-			{
-				m_nodeGlobal = parent->GetGlobalTransform() * m_nodeLocal;
-			}
-			else
-			{
-				m_nodeGlobal = m_nodeLocal;
-			}
+			//MMDNode* parent = m_node->GetParent();
+			//if (parent != nullptr)
+			//{
+			//	m_nodeGlobal = parent->GetGlobalTransform() * m_nodeLocal;
+			//}
+			//else
+			//{
+			//	m_nodeGlobal = m_nodeLocal;
+			//}
 		}
 
 		void EndUpdate() override
 		{
+			glm::mat4 world;
+			m_transform.getOpenGLMatrix(&world[0][0]);
+			m_nodeGlobal = InvZ(world) * m_invOffset;
+			glm::mat4 global = m_node->GetGlobalTransform();
+			m_nodeGlobal[3] = global[3];
+
+			MMDNode* parent = m_node->GetParent();
+			glm::mat4 local;
+			if (parent != nullptr)
+			{
+				local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
+			}
+			else
+			{
+				local = m_nodeGlobal;
+			}
+
+			if (m_override)
+			{
+				m_node->SetLocalTransform(local);
+				m_node->UpdateGlobalTransform();
+			}
 		}
 
 	private:
@@ -316,6 +389,7 @@ namespace saba
 		glm::mat4	m_nodeGlobal;
 		glm::mat4	m_offset;
 		glm::mat4	m_invOffset;
+		btTransform	m_transform;
 		bool		m_override;
 
 	};
@@ -417,7 +491,7 @@ namespace saba
 		auto rx = glm::rotate(glm::mat4(), pmdRigidBody.m_rot.x, glm::vec3(1, 0, 0));
 		auto ry = glm::rotate(glm::mat4(), pmdRigidBody.m_rot.y, glm::vec3(0, 1, 0));
 		auto rz = glm::rotate(glm::mat4(), pmdRigidBody.m_rot.z, glm::vec3(0, 0, 1));
-		glm::mat4 rotMat = rz * ry * rx;
+		glm::mat4 rotMat = ry * rx * rz;
 		glm::mat4 translateMat = glm::translate(glm::mat4(), pmdRigidBody.m_pos);
 
 		glm::mat4 rbMat = translateMat * rotMat;
@@ -545,7 +619,7 @@ namespace saba
 		auto rx = glm::rotate(glm::mat4(), pmxRigidBody.m_rotate.x, glm::vec3(1, 0, 0));
 		auto ry = glm::rotate(glm::mat4(), pmxRigidBody.m_rotate.y, glm::vec3(0, 1, 0));
 		auto rz = glm::rotate(glm::mat4(), pmxRigidBody.m_rotate.z, glm::vec3(0, 0, 1));
-		glm::mat4 rotMat = rz * ry * rx;
+		glm::mat4 rotMat = ry * rx * rz;
 		glm::mat4 translateMat = glm::translate(glm::mat4(), pmxRigidBody.m_translate);
 
 		glm::mat4 rbMat = InvZ(translateMat * rotMat);
@@ -707,24 +781,24 @@ namespace saba
 			m_kinematicMotionState->EndUpdate();
 		}
 
-		if (m_node != nullptr && m_rigidBodyType != RigidBodyType::Kinematic)
-		{
-			glm::mat4 rbMat = GetTransform();
-			glm::mat4 globalMat = rbMat * m_invOffsetMat;
+		//if (m_node != nullptr && m_rigidBodyType != RigidBodyType::Kinematic)
+		//{
+		//	glm::mat4 rbMat = GetTransform();
+		//	glm::mat4 globalMat = rbMat * m_invOffsetMat;
 
-			glm::mat4 localMat;
-			MMDNode* parent = m_node->GetParent();
-			if (parent != nullptr)
-			{
-				localMat = glm::inverse(parent->GetGlobalTransform()) * globalMat;
-			}
-			else
-			{
-				localMat = globalMat;
-			}
-			m_node->SetLocalTransform(localMat);
-			m_node->SetGlobalTransform(globalMat);
-		}
+		//	glm::mat4 localMat;
+		//	MMDNode* parent = m_node->GetParent();
+		//	if (parent != nullptr)
+		//	{
+		//		localMat = glm::inverse(parent->GetGlobalTransform()) * globalMat;
+		//	}
+		//	else
+		//	{
+		//		localMat = globalMat;
+		//	}
+		//	m_node->SetLocalTransform(localMat);
+		//	m_node->SetGlobalTransform(globalMat);
+		//}
 	}
 
 	glm::mat4 MMDRigidBody::GetTransform()

--- a/src/Saba/Model/MMD/MMDPhysics.cpp
+++ b/src/Saba/Model/MMD/MMDPhysics.cpp
@@ -205,46 +205,21 @@ namespace saba
 			, m_override(override)
 		{
 			m_invOffset = glm::inverse(offset);
-			m_nodeGlobal = m_node->GetGlobalTransform();
 			Reset();
 		}
 
 		void getWorldTransform(btTransform& worldTransform) const override
 		{
-			//glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
-			//worldTransform.setFromOpenGLMatrix(&ret[0][0]);
 			worldTransform = m_transform;
 		}
 
 		void setWorldTransform(const btTransform& worldTransform) override
 		{
-			//glm::mat4 world;
-			//worldTransform.getOpenGLMatrix(&world[0][0]);
-			//m_nodeGlobal = InvZ(world) * m_invOffset;
-
-			//MMDNode* parent = m_node->GetParent();
-			//glm::mat4 local;
-			//if (parent != nullptr)
-			//{
-			//	local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
-			//}
-			//else
-			//{
-			//	local = m_nodeGlobal;
-			//}
-
-			//if (m_override)
-			//{
-			//	m_node->SetLocalTransform(local);
-			//	m_node->UpdateGlobalTransform();
-			//}
 			m_transform = worldTransform;
 		}
 
 		void Reset() override
 		{
-			m_nodeGlobal = m_node->GetGlobalTransform();
-
 			glm::mat4 global = InvZ(m_node->GetGlobalTransform() * m_offset);
 			m_transform.setFromOpenGLMatrix(&global[0][0]);
 		}
@@ -257,17 +232,17 @@ namespace saba
 		{
 			glm::mat4 world;
 			m_transform.getOpenGLMatrix(&world[0][0]);
-			m_nodeGlobal = InvZ(world) * m_invOffset;
+			glm::mat4 btGlobal = InvZ(world) * m_invOffset;
 
 			MMDNode* parent = m_node->GetParent();
 			glm::mat4 local;
 			if (parent != nullptr)
 			{
-				local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
+				local = glm::inverse(parent->GetGlobalTransform()) * btGlobal;
 			}
 			else
 			{
-				local = m_nodeGlobal;
+				local = btGlobal;
 			}
 
 			if (m_override)
@@ -279,7 +254,6 @@ namespace saba
 
 	private:
 		MMDNode*	m_node;
-		glm::mat4	m_nodeGlobal;
 		glm::mat4	m_offset;
 		glm::mat4	m_invOffset;
 		btTransform	m_transform;
@@ -295,85 +269,46 @@ namespace saba
 			, m_override(override)
 		{
 			m_invOffset = glm::inverse(offset);
-			m_nodeLocal = m_node->GetLocalTransform();
-			m_nodeGlobal = m_node->GetGlobalTransform();
 			Reset();
 		}
 
 		void getWorldTransform(btTransform& worldTransform) const override
 		{
-			//glm::mat4 ret = InvZ(m_nodeGlobal * m_offset);
-			//worldTransform.setFromOpenGLMatrix(&ret[0][0]);
 			worldTransform = m_transform;
 		}
 
 		void setWorldTransform(const btTransform& worldTransform) override
 		{
-			//glm::mat4 world;
-			//worldTransform.getOpenGLMatrix(&world[0][0]);
-			//world = InvZ(world);
-			//glm::mat4 nodeOffsetGlobal = m_node->GetGlobalTransform() * m_offset;
-			//world[3] = nodeOffsetGlobal[3];
-			//m_nodeGlobal = world * m_invOffset;
-
-			//MMDNode* parent = m_node->GetParent();
-			//if (parent != nullptr)
-			//{
-			//	glm::mat4 local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
-			//	m_nodeLocal = local;
-			//}
-			//else
-			//{
-			//	m_nodeLocal = m_nodeGlobal;
-			//}
-
-			//if (m_override)
-			//{
-			//	m_node->SetLocalTransform(m_nodeLocal);
-			//	m_node->UpdateGlobalTransform();
-			//}
 			m_transform = worldTransform;
 		}
 
 		void Reset() override
 		{
-			m_nodeLocal = m_node->GetLocalTransform();
-			m_nodeGlobal = m_node->GetGlobalTransform();
-
 			glm::mat4 global = InvZ(m_node->GetGlobalTransform() * m_offset);
 			m_transform.setFromOpenGLMatrix(&global[0][0]);
 		}
 
 		void BeginUpdate() override
 		{
-			//MMDNode* parent = m_node->GetParent();
-			//if (parent != nullptr)
-			//{
-			//	m_nodeGlobal = parent->GetGlobalTransform() * m_nodeLocal;
-			//}
-			//else
-			//{
-			//	m_nodeGlobal = m_nodeLocal;
-			//}
 		}
 
 		void EndUpdate() override
 		{
 			glm::mat4 world;
 			m_transform.getOpenGLMatrix(&world[0][0]);
-			m_nodeGlobal = InvZ(world) * m_invOffset;
+			glm::mat4 btGlobal = InvZ(world) * m_invOffset;
 			glm::mat4 global = m_node->GetGlobalTransform();
-			m_nodeGlobal[3] = global[3];
+			btGlobal[3] = global[3];
 
 			MMDNode* parent = m_node->GetParent();
 			glm::mat4 local;
 			if (parent != nullptr)
 			{
-				local = glm::inverse(parent->GetGlobalTransform()) * m_nodeGlobal;
+				local = glm::inverse(parent->GetGlobalTransform()) * btGlobal;
 			}
 			else
 			{
-				local = m_nodeGlobal;
+				local = btGlobal;
 			}
 
 			if (m_override)
@@ -385,8 +320,6 @@ namespace saba
 
 	private:
 		MMDNode*	m_node;
-		glm::mat4	m_nodeLocal;
-		glm::mat4	m_nodeGlobal;
 		glm::mat4	m_offset;
 		glm::mat4	m_invOffset;
 		btTransform	m_transform;
@@ -780,25 +713,6 @@ namespace saba
 		{
 			m_kinematicMotionState->EndUpdate();
 		}
-
-		//if (m_node != nullptr && m_rigidBodyType != RigidBodyType::Kinematic)
-		//{
-		//	glm::mat4 rbMat = GetTransform();
-		//	glm::mat4 globalMat = rbMat * m_invOffsetMat;
-
-		//	glm::mat4 localMat;
-		//	MMDNode* parent = m_node->GetParent();
-		//	if (parent != nullptr)
-		//	{
-		//		localMat = glm::inverse(parent->GetGlobalTransform()) * globalMat;
-		//	}
-		//	else
-		//	{
-		//		localMat = globalMat;
-		//	}
-		//	m_node->SetLocalTransform(localMat);
-		//	m_node->SetGlobalTransform(globalMat);
-		//}
 	}
 
 	glm::mat4 MMDRigidBody::GetTransform()

--- a/src/Saba/Model/MMD/MMDPhysics.h
+++ b/src/Saba/Model/MMD/MMDPhysics.h
@@ -26,6 +26,7 @@ class btDefaultCollisionConfiguration;
 class btCollisionDispatcher;
 class btSequentialImpulseConstraintSolver;
 class btMotionState;
+struct btOverlapFilterCallback;
 
 namespace saba
 {
@@ -132,6 +133,7 @@ namespace saba
 		std::unique_ptr<btCollisionShape>					m_groundShape;
 		std::unique_ptr<btMotionState>						m_groundMS;
 		std::unique_ptr<btRigidBody>						m_groundRB;
+		std::unique_ptr<btOverlapFilterCallback>			m_filterCB;
 	};
 
 }

--- a/src/Saba/Model/MMD/PMDModel.cpp
+++ b/src/Saba/Model/MMD/PMDModel.cpp
@@ -74,37 +74,7 @@ namespace saba
 			solver->Solve();
 		}
 
-		MMDPhysicsManager* physicsMan = GetPhysicsManager();
-		auto physics = physicsMan->GetMMDPhysics();
-
-		if (physics == nullptr)
-		{
-			return;
-		}
-
-		auto rigidbodys = physicsMan->GetRigidBodys();
-		auto joints = physicsMan->GetJoints();
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->SetActivation(false);
-		}
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->BeginUpdate();
-		}
-
-		physics->Update(1.0f / 60.0f);
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->EndUpdate();
-		}
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->Reset(physics);
-		}
+		ResetPhysics();
 	}
 
 	void PMDModel::BeginAnimation()
@@ -141,6 +111,41 @@ namespace saba
 		for (auto& solver : (*m_ikSolverMan.GetIKSolvers()))
 		{
 			solver->Solve();
+		}
+	}
+
+	void PMDModel::ResetPhysics()
+	{
+		MMDPhysicsManager* physicsMan = GetPhysicsManager();
+		auto physics = physicsMan->GetMMDPhysics();
+
+		if (physics == nullptr)
+		{
+			return;
+		}
+
+		auto rigidbodys = physicsMan->GetRigidBodys();
+		auto joints = physicsMan->GetJoints();
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->SetActivation(false);
+		}
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->BeginUpdate();
+		}
+
+		physics->Update(1.0f / 60.0f);
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->EndUpdate();
+		}
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->Reset(physics);
 		}
 	}
 
@@ -533,6 +538,8 @@ namespace saba
 			}
 			m_physicsMan.GetMMDPhysics()->AddJoint(joint);
 		}
+
+		ResetPhysics();
 
 		return true;
 	}

--- a/src/Saba/Model/MMD/PMDModel.cpp
+++ b/src/Saba/Model/MMD/PMDModel.cpp
@@ -523,20 +523,24 @@ namespace saba
 
 		for (const auto& pmdJoint : pmd.m_joints)
 		{
-			auto joint = m_physicsMan.AddJoint();
-			MMDNode* node = nullptr;
-			auto rigidBodys = m_physicsMan.GetRigidBodys();
-			bool ret = joint->CreateJoint(
-				pmdJoint,
-				(*rigidBodys)[pmdJoint.m_rigidBodyA].get(),
-				(*rigidBodys)[pmdJoint.m_rigidBodyB].get()
-			);
-			if (!ret)
+			if (pmdJoint.m_rigidBodyA != -1 &&
+				pmdJoint.m_rigidBodyB != -1)
 			{
-				SABA_ERROR("Create Joint Fail.\n");
-				return false;
+				auto joint = m_physicsMan.AddJoint();
+				MMDNode* node = nullptr;
+				auto rigidBodys = m_physicsMan.GetRigidBodys();
+				bool ret = joint->CreateJoint(
+					pmdJoint,
+					(*rigidBodys)[pmdJoint.m_rigidBodyA].get(),
+					(*rigidBodys)[pmdJoint.m_rigidBodyB].get()
+				);
+				if (!ret)
+				{
+					SABA_ERROR("Create Joint Fail.\n");
+					return false;
+				}
+				m_physicsMan.GetMMDPhysics()->AddJoint(joint);
 			}
-			m_physicsMan.GetMMDPhysics()->AddJoint(joint);
 		}
 
 		ResetPhysics();

--- a/src/Saba/Model/MMD/PMDModel.h
+++ b/src/Saba/Model/MMD/PMDModel.h
@@ -53,6 +53,7 @@ namespace saba
 		// ノードを更新する
 		void UpdateAnimation() override;
 		// Physicsを更新する
+		void ResetPhysics() override;
 		void UpdatePhysics(float elapsed) override;
 		// 頂点データーを更新する
 		void Update() override;

--- a/src/Saba/Model/MMD/PMXModel.cpp
+++ b/src/Saba/Model/MMD/PMXModel.cpp
@@ -78,37 +78,7 @@ namespace saba
 
 		EndAnimation();
 
-		MMDPhysicsManager* physicsMan = GetPhysicsManager();
-		auto physics = physicsMan->GetMMDPhysics();
-
-		if (physics == nullptr)
-		{
-			return;
-		}
-
-		auto rigidbodys = physicsMan->GetRigidBodys();
-		auto joints = physicsMan->GetJoints();
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->SetActivation(false);
-		}
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->BeginUpdate();
-		}
-
-		physics->Update(1.0f / 60.0f);
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->EndUpdate();
-		}
-
-		for (auto& rb : (*rigidbodys))
-		{
-			rb->Reset(physics);
-		}
+		ResetPhysics();
 	}
 
 	void PMXModel::BeginAnimation()
@@ -180,6 +150,41 @@ namespace saba
 			{
 				node->UpdateGlobalTransform();
 			}
+		}
+	}
+
+	void PMXModel::ResetPhysics()
+	{
+		MMDPhysicsManager* physicsMan = GetPhysicsManager();
+		auto physics = physicsMan->GetMMDPhysics();
+
+		if (physics == nullptr)
+		{
+			return;
+		}
+
+		auto rigidbodys = physicsMan->GetRigidBodys();
+		auto joints = physicsMan->GetJoints();
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->SetActivation(false);
+		}
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->BeginUpdate();
+		}
+
+		physics->Update(1.0f / 60.0f);
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->EndUpdate();
+		}
+
+		for (auto& rb : (*rigidbodys))
+		{
+			rb->Reset(physics);
 		}
 	}
 
@@ -889,6 +894,8 @@ namespace saba
 			m_updatePartitions[i] = part;
 			partVertexOffset += part.m_vertexCount;
 		}
+
+		ResetPhysics();
 
 		return true;
 	}

--- a/src/Saba/Model/MMD/PMXModel.cpp
+++ b/src/Saba/Model/MMD/PMXModel.cpp
@@ -848,20 +848,24 @@ namespace saba
 
 		for (const auto& pmxJoint : pmx.m_joints)
 		{
-			auto joint = m_physicsMan.AddJoint();
-			MMDNode* node = nullptr;
-			auto rigidBodys = m_physicsMan.GetRigidBodys();
-			bool ret = joint->CreateJoint(
-				pmxJoint,
-				(*rigidBodys)[pmxJoint.m_rigidbodyAIndex].get(),
-				(*rigidBodys)[pmxJoint.m_rigidbodyBIndex].get()
-			);
-			if (!ret)
+			if (pmxJoint.m_rigidbodyAIndex != -1 &&
+				pmxJoint.m_rigidbodyBIndex != -1)
 			{
-				SABA_ERROR("Create Joint Fail.\n");
-				return false;
+				auto joint = m_physicsMan.AddJoint();
+				MMDNode* node = nullptr;
+				auto rigidBodys = m_physicsMan.GetRigidBodys();
+				bool ret = joint->CreateJoint(
+					pmxJoint,
+					(*rigidBodys)[pmxJoint.m_rigidbodyAIndex].get(),
+					(*rigidBodys)[pmxJoint.m_rigidbodyBIndex].get()
+				);
+				if (!ret)
+				{
+					SABA_ERROR("Create Joint Fail.\n");
+					return false;
+				}
+				m_physicsMan.GetMMDPhysics()->AddJoint(joint);
 			}
-			m_physicsMan.GetMMDPhysics()->AddJoint(joint);
 		}
 
 		size_t asyncCount = m_asyncUpdateCount;

--- a/src/Saba/Model/MMD/PMXModel.h
+++ b/src/Saba/Model/MMD/PMXModel.h
@@ -103,6 +103,7 @@ namespace saba
 		// ノードを更新する
 		void UpdateAnimation() override;
 		// Physicsを更新する
+		void ResetPhysics() override;
 		void UpdatePhysics(float elapsed) override;
 		// 頂点データーを更新する
 		void Update() override;

--- a/viewer/Saba/GL/Model/MMD/GLMMDModelDrawer.cpp
+++ b/viewer/Saba/GL/Model/MMD/GLMMDModelDrawer.cpp
@@ -124,11 +124,6 @@ namespace saba
 	void GLMMDModelDrawer::InitializeAnimation(ViewerContext* ctxt)
 	{
 		m_mmdModel->EvaluateAnimation(ctxt->GetAnimationTime());
-		auto model = m_mmdModel->GetMMDModel();
-		if (model != nullptr)
-		{
-			model->InitializeAnimation();
-		}
 	}
 
 	void GLMMDModelDrawer::Update(ViewerContext * ctxt)


### PR DESCRIPTION
物理挙動の実装がおかしかったのを修正。
Bullet の btMotionState でマトリクスを設定された際に、値をすぐに反映するのは間違いだった。
また、アニメーション時に、ノードの情報を「ノード追従」以外の Rigidbody に反映するもの間違い（多分）。

MMM の挙動を見ていて、Joint でつながれていない「物理＋ボーン位置合わせ」の Rigidbody が落ちていくが、モデル表示では位置が変化したいのを見て判明。