### PR TITLE
Don't try to fix not found group morph

### DIFF
--- a/src/Saba/Model/MMD/PMXModel.cpp
+++ b/src/Saba/Model/MMD/PMXModel.cpp
@@ -828,7 +828,10 @@ namespace saba
 						else
 						{
 							groupMorphStack.push_back(morphIdx);
-							fixInifinitGropuMorph(groupMorph.m_morphIndex);
+							if (groupMorph.m_morphIndex>0)
+								fixInifinitGropuMorph(groupMorph.m_morphIndex);
+							else
+								SABA_ERROR("Invalid morph index: group={}, morph={}", groupMorph.m_morphIndex, morphIdx);
 							groupMorphStack.pop_back();
 						}
 					}


### PR DESCRIPTION
Some models have -1 `groupMorph.m_morphIndex`, and this also can cause a segfault on group fixing step.