### PR TITLE
Add stdint include

### DIFF
--- a/src/Saba/Base/UnicodeUtil.cpp
+++ b/src/Saba/Base/UnicodeUtil.cpp
@@ -6,6 +6,7 @@
 #include "UnicodeUtil.h"
 
 #include <stdexcept>
+#include <stdint.h>
 
 namespace saba
 {


### PR DESCRIPTION
stdint header are required for uint8_t, uint32_t, etc.